### PR TITLE
[ECHOJS-76] fix: drop connection without errors

### DIFF
--- a/src/echo/ws/index.js
+++ b/src/echo/ws/index.js
@@ -41,8 +41,8 @@ class WS extends EventEmitter {
 		});
 
 		try {
-			await this._ws_rpc.login('', '');
 			await Promise.all(initPromises);
+			await this._ws_rpc.login('', '');
 		} catch (e) {
 			console.error('[WS] >---- error ----->  ONOPEN', e);
 			await this.close();


### PR DESCRIPTION
Timeouts inside promises were executed ( reject(new Error('')) ) before its were watched by try/catch construction. 