### PR TITLE
[ECHOJS-88] fix: closing process in contracts' tests

### DIFF
--- a/src/constants/ws-constants.js
+++ b/src/constants/ws-constants.js
@@ -3,6 +3,7 @@ export const MAX_RETRIES = 1000;
 export const PING_TIMEOUT = 10 * 1000;
 export const PING_DELAY = 10 * 1000;
 export const DEBUG = false;
+export const CONNECTION_CLOSED_ERROR_MESSAGE = 'connection closed';
 
 export const DATABASE_API = 'database';
 export const NETWORK_BROADCAST_API = 'network_broadcast';

--- a/src/echo/api.js
+++ b/src/echo/api.js
@@ -2358,9 +2358,11 @@ class API {
 			}
 		}
 
-		const contract = await this.getContract(contractId, force);
-		const balances = await this.getContractBalances(contractId);
-		const history = await this.getContractHistory(contractId);
+		const [contract, balances, history] = await Promise.all([
+			this.getContract(contractId, force),
+			this.getContractBalances(contractId),
+			this.getContractHistory(contractId),
+		]);
 
 		this.cache.setInMap(
 			CacheMaps.FULL_CONTRACTS_BY_CONTRACT_ID,

--- a/src/echo/subscriber.js
+++ b/src/echo/subscriber.js
@@ -490,7 +490,10 @@ class Subscriber extends EventEmitter {
 
 		if (isContractHistoryId(object.id)) {
 			this._notifyContractSubscribers(obj);
-			this._api.getFullContract(object.contract, true);
+			this._api.getFullContract(object.contract, true).catch((err) => {
+				if (err.message === 'connection closed') return;
+				throw err;
+			});
 		}
 
 		return null;

--- a/src/echo/subscriber.js
+++ b/src/echo/subscriber.js
@@ -1,7 +1,7 @@
 import EventEmitter from 'events';
 import { Map, Set, fromJS } from 'immutable';
 
-import { STATUS, CONNECTION_CLOSED_ERROR_MESSAGE } from '../constants/ws-constants';
+import { STATUS } from '../constants/ws-constants';
 
 import {
 	isFunction,
@@ -34,18 +34,7 @@ import {
 } from '../constants';
 
 import * as CacheMaps from '../constants/cache-maps';
-
-/**
- * @param {Error} error
- * @param {() => any} [handler]
- */
-function handleConnectionClosedError(error, handler) {
-	if (error.message === CONNECTION_CLOSED_ERROR_MESSAGE) {
-		if (handler) handler();
-		return;
-	}
-	throw error;
-}
+import { handleConnectionClosedError } from '../utils/helpers';
 
 class Subscriber extends EventEmitter {
 

--- a/src/echo/ws/reconnection-websocket.js
+++ b/src/echo/ws/reconnection-websocket.js
@@ -7,6 +7,7 @@ import {
 	PING_TIMEOUT,
 	PING_DELAY,
 	DEBUG,
+	CONNECTION_CLOSED_ERROR_MESSAGE,
 } from '../../constants/ws-constants';
 
 import { isVoid } from '../../utils/validators';
@@ -353,7 +354,7 @@ class ReconnectionWebSocket {
 	 * @private
 	 */
 	_clearWaitingCallPromises() {
-		const err = new Error('connection closed');
+		const err = new Error(CONNECTION_CLOSED_ERROR_MESSAGE);
 
 		for (let cbId = this._responseCbId + 1; cbId <= this._cbId; cbId += 1) {
 			if (this._cbs[cbId]) this._cbs[cbId].reject(err);

--- a/src/index.js
+++ b/src/index.js
@@ -31,4 +31,6 @@ export {
 	PublicKeyECDSA,
 };
 
+export { handleConnectionClosedError } from './utils/helpers';
+
 export default new Echo();

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -6,9 +6,6 @@ import { CONNECTION_CLOSED_ERROR_MESSAGE } from '../constants/ws-constants';
  * @param {() => any} [handler]
  */
 export function handleConnectionClosedError(error, handler) {
-	if (error.message === CONNECTION_CLOSED_ERROR_MESSAGE) {
-		if (handler) handler();
-		return;
-	}
+	if (error.message === CONNECTION_CLOSED_ERROR_MESSAGE) return handler && handler();
 	throw error;
 }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,0 +1,14 @@
+/* eslint-disable import/prefer-default-export */
+import { CONNECTION_CLOSED_ERROR_MESSAGE } from '../constants/ws-constants';
+
+/**
+ * @param {Error} error
+ * @param {() => any} [handler]
+ */
+export function handleConnectionClosedError(error, handler) {
+	if (error.message === CONNECTION_CLOSED_ERROR_MESSAGE) {
+		if (handler) handler();
+		return;
+	}
+	throw error;
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,6 +11,7 @@ export { default as ED25519 } from './crypto/ed25519';
 export { default as AES } from './crypto/aes';
 export { default as hash } from './crypto/hash';
 export { default as echoReducer } from './redux/reducer';
+export { handleConnectionClosedError } from './utils/helpers';
 export { validators };
 export { converters };
 

--- a/types/utils/helpers.d.ts
+++ b/types/utils/helpers.d.ts
@@ -1,0 +1,1 @@
+export function handleConnectionClosedError<T>(error: Error, handler?: () => T): T;


### PR DESCRIPTION
* optimize `Api#getFullContract` method
* catch "connection closed" error of contract history updating in cache
* catch "connection closed" error of account updating in cache
* move "connection closed" error message in ws-constants
* add "handleConnectionClosedError" function