### PR TITLE
Using primitives instead of wrappers

### DIFF
--- a/types/crypto/hash.d.ts
+++ b/types/crypto/hash.d.ts
@@ -1,16 +1,15 @@
 import {Buffer} from 'buffer';
 
-declare function sha1(data: string|Buffer, encoding: string): String|Buffer;
-declare function sha256(data: string|Buffer, encoding: string): String|Buffer;
-declare function sha512(data: string|Buffer, encoding: string): String|Buffer;
-declare function HmacSHA256(data: Buffer, secret: Buffer): String|Buffer;
-declare function ripemd160(data: Buffer): String|Buffer;
-
+export function sha1(data: string|Buffer, encoding: string): string|Buffer;
+export function sha256(data: string|Buffer, encoding: string): string|Buffer;
+export function sha512(data: string|Buffer, encoding: string): string|Buffer;
+export function HmacSHA256(data: Buffer, secret: Buffer): string|Buffer;
+export function ripemd160(data: Buffer): string|Buffer;
 
 export default interface Hash {
-	sha1(data: string|Buffer, encoding: string): String|Buffer,
-	sha256(data: string|Buffer, encoding: string): String|Buffer,
-	sha512(data: string|Buffer, encoding: string): String|Buffer,
-	HmacSHA256(data: Buffer, secret: Buffer): String|Buffer,
-	ripemd160(data: Buffer): String|Buffer,
+	sha1(data: string|Buffer, encoding: string): string|Buffer,
+	sha256(data: string|Buffer, encoding: string): string|Buffer,
+	sha512(data: string|Buffer, encoding: string): string|Buffer,
+	HmacSHA256(data: Buffer, secret: Buffer): string|Buffer,
+	ripemd160(data: Buffer): string|Buffer,
 }

--- a/types/crypto/private-key.d.ts
+++ b/types/crypto/private-key.d.ts
@@ -4,14 +4,14 @@ export default class PrivateKey {
 	static fromWif(wif: string): PrivateKey;
 	toPublicKey(): PublicKey;
 	static fromBuffer(buf: Buffer): PrivateKey;
-	static fromSeed(seed: String): PrivateKey;
-	static fromWif(_privateWIF: String): PrivateKey;
-	toWif(): String;
+	static fromSeed(seed: string): PrivateKey;
+	static fromWif(_privateWIF: string): PrivateKey;
+	toWif(): string;
 	toPublicKey(): PublicKey;
 	toBuffer(): Buffer;
 	getSharedSecret(): Buffer;
-	static fromHex(hex: String): PrivateKey;
-	toHex(): String;
-	toPrivateKeyString(): String;
-	static fromPrivateKeyString(privateKeyString: String): PrivateKey|null;
+	static fromHex(hex: string): PrivateKey;
+	toHex(): string;
+	toPrivateKeyString(): string;
+	static fromPrivateKeyString(privateKeyString: string): PrivateKey|null;
 }

--- a/types/crypto/public-key.d.ts
+++ b/types/crypto/public-key.d.ts
@@ -2,16 +2,16 @@ import * as ByteBuffer from "bytebuffer";
 
 export default class PublicKey {
 	toString(addressPrefix?: string): string;
-	static fromPublicKeyString(publicKey: string, addressPrefix?: string): PublicKey | null;
-	static fromBinary(bin: String): PublicKey;
+	static fromPublicKeyString(publicKey: string, addressPrefix?: string): PublicKey|null;
+	static fromBinary(bin: string): PublicKey;
 	static fromBuffer(buffer: Buffer): PublicKey;
 	toBuffer(): Buffer;
-	toBlockchainAddress(): String;
-	toPublicKeyString(addressPrefix?: String): String;
-	fromPublicKeyString(publicKey: String, addressPrefix?: String): PublicKey | null;
-	fromStringOrThrow(publicKey: String, addressPrefix?: String): PublicKey;
+	toBlockchainAddress(): string;
+	toPublicKeyString(addressPrefix?: string): string;
+	fromPublicKeyString(publicKey: string, addressPrefix?: string): PublicKey|null;
+	fromStringOrThrow(publicKey: string, addressPrefix?: string): PublicKey;
 	toByteBuffer(): ByteBuffer;
-	static fromHex(hex: String): PublicKey;
-	toHex(): String;
-	static fromPublicKeyStringHex(hex: String): PublicKey;
+	static fromHex(hex: string): PublicKey;
+	toHex(): string;
+	static fromPublicKeyStringHex(hex: string): PublicKey;
 }

--- a/types/echo/api.d.ts
+++ b/types/echo/api.d.ts
@@ -34,8 +34,8 @@ import { uint32 } from '../serializers/basic/integers';
 type SidechainType = "" | "eth" | "btc";
 
 export default class Api {
-	broadcastTransaction(tr: Object): Promise<any>;
-	broadcastTransactionWithCallback(signedTransactionObject: Object, wasBroadcastedCallback?: () => any): Promise<any>;
+	broadcastTransaction(tr: object): Promise<any>;
+	broadcastTransactionWithCallback(signedTransactionObject: object, wasBroadcastedCallback?: () => any): Promise<any>;
 	checkERC20Token(contractId: string): Promise<boolean>;
 	get24Volume(baseAssetName: string, quoteAssetName: string): Promise<any>;
 	getAccounts(accountIds: Array<string>, force?: boolean): Promise<Array<Account>>;
@@ -58,8 +58,8 @@ export default class Api {
 	getAssetHolders(assetId: string, start: number, limit: number): Promise<Array<{name: string, account_id: string, amount: string}>>;
 	getAssetHoldersCount(assetId: string): Promise<number>;
 	getAssets(assetIds: Array<string>, force?: boolean): Promise<Array<Asset>>;
-	getBalanceObjects(keys: Object): any;
-	getBitAssetData(bitAssetId: string, force?: boolean): Promise<Object>;
+	getBalanceObjects(keys: object): any;
+	getBitAssetData(bitAssetId: string, force?: boolean): Promise<object>;
 	getBlock(blockNum: number): Promise<Block>;
 	getBlockHeader(blockNum: number): Promise<BlockHeader>;
 	getBlockRewards(blockNum: typeof uint32["__TInput__"]): Promise<unknown>;
@@ -67,10 +67,10 @@ export default class Api {
 	getBtcAddress(accountId: string): Promise<Array<BtcAddress>>;
 	getAccountAddresses(accountId: string, from: number, limit: number): Promise<Array<AccountAddress>>;
 	getEthAddress(accountId: string): Promise<AccountEthAddress>;
-	getBtcDepositScript(btcDepositId: string): Promise<String>;
+	getBtcDepositScript(btcDepositId: string): Promise<string>;
 	getChainId(force?: boolean): Promise<string>
 	getChainProperties(force?: boolean): Promise<ChainProperties>;
-	getCommitteeFrozenBalance(committeeMemberId: string): Promise<Object>;
+	getCommitteeFrozenBalance(committeeMemberId: string): Promise<object>;
 	getCommitteeMembers(committeeMemberIds: Array<string>, force?: boolean): Promise<Array<Committee>>;
 	getCommitteeMemberByAccount(accountId: string, force?: boolean): Promise<Committee>;
 	getConfig(force?: boolean): Promise<Config>;
@@ -87,28 +87,28 @@ export default class Api {
 	}): Promise<unknown[]>;
 	getContractPoolBalance(resultContractId: string, force?: boolean): Promise<{asset_id: string, amount: number}>;
 	getContractResult(resultContractId: string, force?: boolean): Promise<ContractResult>;
-	getDynamicAssetData(dynamicAssetDataId: string, force?: boolean): Promise<Object>;
+	getDynamicAssetData(dynamicAssetDataId: string, force?: boolean): Promise<object>;
 	getDynamicGlobalProperties(force?: boolean): Promise<DynamicGlobalProperties>;
 	getFeePool(assetId: string): Promise<BigNumber>;
 	getFrozenBalances(accountId: string): Promise<Array<FrozenBalance>>;
 	getFullAccounts(accountNamesOrIds: Array<string>, subscribe?: boolean, force?: boolean): Promise<Array<FullAccount>>;
-	getFullContract(contractId: string, force?: boolean): Promise<Object>;
+	getFullContract(contractId: string, force?: boolean): Promise<object>;
 	getGlobalProperties(force?: boolean): Promise<GlobalProperties>;
 	getKeyReferences(keys: Array<string | PublicKey>, force?: boolean): Promise<string[][]>;
 	getMarginPositions(accountId: string): Promise<any>;
-	getNamedAccountBalances(accountName: string, assetIds: Array<string>, force?: boolean): Promise<Object>;
-	getObject(objectId: string, force?: boolean): Promise<Object>;
-	getObjects(objectIds: string, force?: boolean): Promise<Array<Object>>;
-	getPotentialSignatures(tr: Object): Promise<any>;
+	getNamedAccountBalances(accountName: string, assetIds: Array<string>, force?: boolean): Promise<object>;
+	getObject(objectId: string, force?: boolean): Promise<object>;
+	getObjects(objectIds: string, force?: boolean): Promise<Array<object>>;
+	getPotentialSignatures(tr: object): Promise<any>;
 	getProposedTransactions(accountNameOrId: string): Promise<any>;
 	getRecentTransactionById(transactionId: string): Promise<any>;
 	getRelativeAccountHistory(accountId: string, stop: number, limit: number, start: number): Promise<Array<AccountHistory>>;
-	getRequiredFees(operations: Array<Object>, assetId: string): Promise<Array<{asset_id: string, amount: number}>>;
-	getRequiredSignatures(tr: Object, availableKey: Array<string>): Promise<any>;
+	getRequiredFees(operations: Array<object>, assetId: string): Promise<Array<{asset_id: string, amount: number}>>;
+	getRequiredSignatures(tr: object, availableKey: Array<string>): Promise<any>;
 	getTicker(baseAssetName: string, quoteAssetName: string): Promise<any>;
 	getTradeHistory(baseAssetName: string, quoteAssetName: number, start: number, stop: number, limit: number): Promise<any>;
 	getTransaction(blockNum: number, transactionIndex: number): Promise<TransactionObject>;
-	getTransactionHex(tr: Object): Promise<any>;
+	getTransactionHex(tr: object): Promise<any>;
 	getVestedBalances(balanceIds: Array<string>): Promise<any>;
 	getVestingBalances(balanceIds: Array<string>): Promise<any>;
 
@@ -133,9 +133,9 @@ export default class Api {
 	): Promise<[{ block_num: number, tx_id: string }]>;
 
 	requestRegistrationTask(): Promise<RegistrationTask>
-	validateTransaction(tr: Object): Promise<any>;
-	verifyAuthority(tr: Object): Promise<any>;
-	verifyAccountAuthority(accountNameOrId: Object, signers: Array<string>): Promise<any>;
+	validateTransaction(tr: object): Promise<any>;
+	verifyAuthority(tr: object): Promise<any>;
+	verifyAccountAuthority(accountNameOrId: object, signers: Array<string>): Promise<any>;
 
 	getConnectedPeers(): Promise<Array<{ version: number, host: string, info: PeerDetails }>>;
 	getPotentialPeers(): Promise<PotentialPeerRecord[]>;

--- a/types/interfaces/Asset.d.ts
+++ b/types/interfaces/Asset.d.ts
@@ -1,10 +1,10 @@
 export default interface Asset {
-	id: string,
-	symbol: string,
-	precision:Number,
-	issuer: string,
-	options: Object,
-	dynamic_asset_data_id: string,
-	dynamic: Object,
-	bitasset: (Object | undefined)
+	id: string;
+	symbol: string;
+	precision:number;
+	issuer: string;
+	options: object;
+	dynamic_asset_data_id: string;
+	dynamic: object;
+	bitasset: object|undefined;
 }

--- a/types/interfaces/Block.d.ts
+++ b/types/interfaces/Block.d.ts
@@ -11,6 +11,6 @@ export default interface Block {
 	ed_signature: string,
 	round: number,
 	rand: string,
-	cert: Object,
+	cert: object,
 	transactions: TransactionObject[],
 }

--- a/types/interfaces/CommitteeFrozenBalance.d.ts
+++ b/types/interfaces/CommitteeFrozenBalance.d.ts
@@ -1,4 +1,4 @@
 export default interface CommitteeFrozenBalance {
-    owner: String,
-    balance: Number
+    owner: string,
+    balance: number
 }

--- a/types/interfaces/GlobalProperties.d.ts
+++ b/types/interfaces/GlobalProperties.d.ts
@@ -1,5 +1,5 @@
 export default interface GlobalProperties {
 	id: string,
-	parameters: Object,
+	parameters: object,
 	active_committee_members: Array<Array<string>>,
 }

--- a/types/redux/reducer.d.ts
+++ b/types/redux/reducer.d.ts
@@ -1,1 +1,1 @@
-export default function (caches?: Array<String>): object;
+export default function (caches?: Array<string>): object;


### PR DESCRIPTION
Fix typing:
* using primitives instead of wrappers:
  * `String` >> `string`
  * `Number` >> `number`
* using non-primitive type (`object`) instead of object's interface